### PR TITLE
Fix integration between TeacherDashboard and website

### DIFF
--- a/TeacherDashboard/api.php
+++ b/TeacherDashboard/api.php
@@ -1,0 +1,181 @@
+<?php
+
+require_once '../webseite/classes/SubjectData.php';
+require_once '../webseite/classes/TopicData.php';
+
+header('Content-Type: application/json');
+
+$method = $_SERVER['REQUEST_METHOD'];
+$path = explode('/', trim($_SERVER['PATH_INFO'], '/'));
+
+if (count($path) < 1) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid API request']);
+    exit;
+}
+
+$resource = $path[0];
+
+switch ($resource) {
+    case 'subjects':
+        handleSubjects($method);
+        break;
+    case 'topics':
+        handleTopics($method);
+        break;
+    default:
+        http_response_code(404);
+        echo json_encode(['error' => 'Resource not found']);
+        break;
+}
+
+function handleSubjects($method)
+{
+    switch ($method) {
+        case 'POST':
+            createSubject();
+            break;
+        case 'PUT':
+            updateSubject();
+            break;
+        default:
+            http_response_code(405);
+            echo json_encode(['error' => 'Method not allowed']);
+            break;
+    }
+}
+
+function handleTopics($method)
+{
+    switch ($method) {
+        case 'POST':
+            createTopic();
+            break;
+        case 'PUT':
+            updateTopic();
+            break;
+        default:
+            http_response_code(405);
+            echo json_encode(['error' => 'Method not allowed']);
+            break;
+    }
+}
+
+function createSubject()
+{
+    $data = json_decode(file_get_contents('php://input'), true);
+
+    if (!isset($data['id'], $data['displayName'], $data['description'], $data['color'], $data['icon'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing required fields']);
+        return;
+    }
+
+    $subject = SubjectData::createNew(
+        $data['id'],
+        $data['displayName'],
+        $data['description'],
+        $data['color'],
+        $data['icon'],
+        []
+    );
+
+    if ($subject && $subject->save()) {
+        http_response_code(201);
+        echo json_encode(['message' => 'Subject created successfully']);
+    } else {
+        http_response_code(500);
+        echo json_encode(['error' => 'Failed to create subject']);
+    }
+}
+
+function updateSubject()
+{
+    $data = json_decode(file_get_contents('php://input'), true);
+
+    if (!isset($data['id'], $data['displayName'], $data['description'], $data['color'], $data['icon'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing required fields']);
+        return;
+    }
+
+    $subject = SubjectData::fromName($data['id']);
+    if (!$subject) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Subject not found']);
+        return;
+    }
+
+    $subject->setDisplayName($data['displayName']);
+    $subject->setDescription($data['description']);
+    $subject->setColor($data['color']);
+    $subject->setIcon($data['icon']);
+
+    if ($subject->save()) {
+        http_response_code(200);
+        echo json_encode(['message' => 'Subject updated successfully']);
+    } else {
+        http_response_code(500);
+        echo json_encode(['error' => 'Failed to update subject']);
+    }
+}
+
+function createTopic()
+{
+    $data = json_decode(file_get_contents('php://input'), true);
+
+    if (!isset($data['id'], $data['subjectId'], $data['displayName'], $data['icon'], $data['description'], $data['article'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing required fields']);
+        return;
+    }
+
+    $topic = TopicData::createNew(
+        $data['id'],
+        $data['subjectId'],
+        $data['displayName'],
+        $data['icon'],
+        $data['description'],
+        [],
+        $data['article']
+    );
+
+    if ($topic && $topic->save()) {
+        http_response_code(201);
+        echo json_encode(['message' => 'Topic created successfully']);
+    } else {
+        http_response_code(500);
+        echo json_encode(['error' => 'Failed to create topic']);
+    }
+}
+
+function updateTopic()
+{
+    $data = json_decode(file_get_contents('php://input'), true);
+
+    if (!isset($data['id'], $data['subjectId'], $data['displayName'], $data['icon'], $data['description'], $data['article'])) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Missing required fields']);
+        return;
+    }
+
+    $topic = TopicData::fromName($data['subjectId'], $data['id']);
+    if (!$topic) {
+        http_response_code(404);
+        echo json_encode(['error' => 'Topic not found']);
+        return;
+    }
+
+    $topic->setDisplayName($data['displayName']);
+    $topic->setIcon($data['icon']);
+    $topic->setDescription($data['description']);
+    $topic->setArticle($data['article']);
+
+    if ($topic->save()) {
+        http_response_code(200);
+        echo json_encode(['message' => 'Topic updated successfully']);
+    } else {
+        http_response_code(500);
+        echo json_encode(['error' => 'Failed to update topic']);
+    }
+}

--- a/TeacherDashboard/js/subjects/subjectManager.js
+++ b/TeacherDashboard/js/subjects/subjectManager.js
@@ -74,8 +74,20 @@ export class SubjectManager {
             const subject = new SubjectModel(subjectData);
             subject.validate();
 
-            await this.storage.saveSubject(subject.toJSON());
-            this.updateSubjectsList(subject.toJSON());
+            const response = await fetch('api.php/subjects', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(subject.toJSON())
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to create subject');
+            }
+
+            const result = await response.json();
+            this.handleApiResponse(result);
             closeModal('subjectModal');
             e.target.reset();
             
@@ -135,5 +147,13 @@ export class SubjectManager {
             </div>
         `;
         return div;
+    }
+
+    handleApiResponse(response) {
+        if (response.message) {
+            showNotification(response.message, 'success');
+        } else if (response.error) {
+            showNotification(response.error, 'error');
+        }
     }
 }

--- a/TeacherDashboard/js/topics/topicManager.js
+++ b/TeacherDashboard/js/topics/topicManager.js
@@ -154,7 +154,7 @@ export class TopicManager {
         }
     }
 
-    handleTopicSubmit(e) {
+    async handleTopicSubmit(e) {
         e.preventDefault();
         const formData = new FormData(e.target);
         const content = this.quill.root.innerHTML;
@@ -164,9 +164,43 @@ export class TopicManager {
             throw new Error('Bitte wählen Sie ein Fach aus');
         }
 
-        // Add your topic saving logic here
-        
-        closeModal('topicModal');
+        const topicData = {
+            id: formData.get('id') || crypto.randomUUID(),
+            subjectId: subjectId,
+            displayName: formData.get('displayName'),
+            icon: formData.get('icon'),
+            description: formData.get('description'),
+            article: content
+        };
+
+        try {
+            const response = await fetch('api.php/topics', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(topicData)
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to create topic');
+            }
+
+            const result = await response.json();
+            this.handleApiResponse(result);
+            closeModal('topicModal');
+            e.target.reset();
+        } catch (error) {
+            throw new Error(`Failed to create topic: ${error.message}`);
+        }
+    }
+
+    handleApiResponse(response) {
+        if (response.message) {
+            showNotification(response.message, 'success');
+        } else if (response.error) {
+            showNotification(response.error, 'error');
+        }
     }
 
     clearEditor() {

--- a/webseite/classes/SubjectData.php
+++ b/webseite/classes/SubjectData.php
@@ -76,6 +76,46 @@ class SubjectData
     }
 
     /**
+     * Erstellt ein neues Fach aus API-Anfragedaten. Es wird noch nichts gespeichert!
+     * @param array $data Die API-Anfragedaten
+     * @return SubjectData|false Neues Fach oder false, wenn ein Fehler auftritt
+     */
+    public static function createFromApiData(array $data): SubjectData|false
+    {
+        if (!isset($data['id'], $data['displayName'], $data['description'], $data['color'], $data['icon'])) {
+            return false;
+        }
+
+        return self::createNew(
+            $data['id'],
+            $data['displayName'],
+            $data['description'],
+            $data['color'],
+            $data['icon'],
+            []
+        );
+    }
+
+    /**
+     * Aktualisiert ein bestehendes Fach aus API-Anfragedaten
+     * @param array $data Die API-Anfragedaten
+     * @return bool true, wenn erfolgreich, sonst false
+     */
+    public function updateFromApiData(array $data): bool
+    {
+        if (!isset($data['displayName'], $data['description'], $data['color'], $data['icon'])) {
+            return false;
+        }
+
+        $this->setDisplayName($data['displayName']);
+        $this->setDescription($data['description']);
+        $this->setColor($data['color']);
+        $this->setIcon($data['icon']);
+
+        return true;
+    }
+
+    /**
      * Prüft, ob das Thema zu den angegebenen IDs existiert
      * @param string $subjectId ID des Faches
      * @return bool true, wenn es existiert, sonst false

--- a/webseite/classes/TopicData.php
+++ b/webseite/classes/TopicData.php
@@ -104,6 +104,47 @@ class TopicData
     }
 
     /**
+     * Erstellt ein neues Thema aus API-Anfragedaten. Es wird noch nichts gespeichert!
+     * @param array $data Die API-Anfragedaten
+     * @return TopicData|false Neues Thema oder false, wenn ein Fehler auftritt
+     */
+    public static function createFromApiData(array $data): TopicData|false
+    {
+        if (!isset($data['id'], $data['subjectId'], $data['displayName'], $data['icon'], $data['description'], $data['article'])) {
+            return false;
+        }
+
+        return self::createNew(
+            $data['id'],
+            $data['subjectId'],
+            $data['displayName'],
+            $data['icon'],
+            $data['description'],
+            [],
+            $data['article']
+        );
+    }
+
+    /**
+     * Aktualisiert ein bestehendes Thema aus API-Anfragedaten
+     * @param array $data Die API-Anfragedaten
+     * @return bool true, wenn erfolgreich, sonst false
+     */
+    public function updateFromApiData(array $data): bool
+    {
+        if (!isset($data['displayName'], $data['icon'], $data['description'], $data['article'])) {
+            return false;
+        }
+
+        $this->setDisplayName($data['displayName']);
+        $this->setIcon($data['icon']);
+        $this->setDescription($data['description']);
+        $this->setArticle($data['article']);
+
+        return true;
+    }
+
+    /**
      * Prüft, ob das Thema zu den angegebenen IDs existiert
      * @param string $subjectId ID des Faches
      * @param string $topicId ID des Themas


### PR DESCRIPTION
Integrate the TeacherDashboard with the main project to allow teachers to create and edit subjects and topics, with changes applied to the website.

* **TeacherDashboard/api.php**: Add API endpoints for creating and updating subjects and topics. Include necessary headers and error handling for API responses.
* **TeacherDashboard/js/subjects/subjectManager.js**: Update `handleSubjectSubmit` method to send API request to `api.php` for creating subjects. Add method to handle API response and update UI accordingly.
* **TeacherDashboard/js/topics/topicManager.js**: Update `handleTopicSubmit` method to send API request to `api.php` for creating topics. Add method to handle API response and update UI accordingly.

